### PR TITLE
[bug-3] Allow doxygen to use dia

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
         
-      - name: Doxygen to GH-pages
+    - name: Doxygen to GH-pages
       uses: jard-111/doxygen-action@1.0
       with:
         # Path to Doxyfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,8 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
         
-    - name: Doxygen Action
-      uses: mattnotmitt/doxygen-action@v1.1.0
+      - name: Doxygen to GH-pages
+      uses: jard-111/doxygen-action@1.0
       with:
         # Path to Doxyfile
         doxyfile-path: "./docs/Doxyfile" # default is ./Doxyfile


### PR DESCRIPTION
I modified the previous action on [my github](<https://github.com/jard-111/doxygen-action>).
This new action allow doxygen to directly use dia diagrams in the documentation.